### PR TITLE
gitService.ts erstellt. Closes #9, #10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,27 +7,26 @@ on:
     branches: [dev, main]
 
 jobs:
+  # --- Consider updating build-frontend as well ---
   build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
-
-      - name: Install Frontend Dependencies
-        working-directory: apps/frontend
-        run: pnpm install
-
+          version: latest # Use latest or match your local pnpm version (e.g., '10')
+          run_install: false # We'll run install manually from the root
+      - name: Install Dependencies (Root) # Install from root
+        run: pnpm install --frozen-lockfile # Recommended for CI
+      - name: Build shared-types # Build shared types if frontend depends on it
+        run: pnpm --filter shared-types build # Add if needed
       - name: Build Frontend
-        working-directory: apps/frontend
+        working-directory: apps/frontend # Keep WD for build command
         run: pnpm run build
 
   build-backend:
@@ -38,18 +37,24 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18' # Ensure this matches your local environment if possible
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          # Use latest or match your local pnpm version (e.g., '10')
+          version: latest # Changed from 8 to latest - align with local if possible
+          run_install: false # Prevent the action from running install automatically
 
-      - name: Install Backend Dependencies
-        working-directory: apps/backend
-        run: pnpm install
+      # --- Corrected Dependency Installation ---
+      - name: Install Dependencies (Root) # <-- Changed name and removed working-directory
+        run: pnpm install --frozen-lockfile # Install from the root, use frozen lockfile for CI
 
+      # --- Added Build Step for Dependency ---
+      - name: Build shared-types # <-- Added step
+        run: pnpm --filter shared-types build # Build the shared package first
+
+      # --- Type Check in Correct Directory ---
       - name: TypeScript Check
-        working-directory: apps/backend
+        working-directory: apps/backend # <-- Keep working-directory here
         run: pnpm exec tsc --noEmit
-

--- a/apps/backend/src/services/gitService.ts
+++ b/apps/backend/src/services/gitService.ts
@@ -1,4 +1,4 @@
-import simpleGit, { SimpleGit, SimpleGitOptions, DefaultLogFields, ListLogLine } from 'simple-git'; // Import necessary types
+import simpleGit, { SimpleGit, SimpleGitOptions, DefaultLogFields } from 'simple-git'; // Import necessary types
 import { mkdtemp, rm } from 'fs/promises';
 import path from 'path';
 import os from 'os';

--- a/apps/backend/src/services/gitService.ts
+++ b/apps/backend/src/services/gitService.ts
@@ -1,21 +1,36 @@
-import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
-import { mkdtemp, rm } from 'fs/promises'; // Use promises API for async/await
+import simpleGit, { SimpleGit, SimpleGitOptions, DefaultLogFields, ListLogLine } from 'simple-git'; // Import necessary types
+import { mkdtemp, rm } from 'fs/promises';
 import path from 'path';
-import os from 'os'; // To get the system's temporary directory
+import os from 'os';
+import { Commit } from 'shared-types'; // Import the Commit interface
 
 // Optional: Define more specific options if needed
 const gitOptions: Partial<SimpleGitOptions> = {
-  baseDir: process.cwd(), // Set the base directory for operations
+  baseDir: process.cwd(),
   binary: 'git',
   maxConcurrentProcesses: 6,
 };
 
+// Define the fields we expect from simple-git log based on the default structure
+// Note: simple-git types might evolve, adjust if needed.
+// This interface helps ensure we handle the expected log data.
+interface GitLogEntry extends DefaultLogFields {
+    hash: string;
+    date: string; // ISO 8601 format string
+    message: string;
+    author_name: string;
+    author_email: string;
+    // refs, body, etc. are also available if needed later
+}
+
 class GitService {
+  // No changes needed for the constructor or the existing cloneRepository/cleanupRepository methods
+
   private git: SimpleGit;
 
   constructor() {
     this.git = simpleGit(gitOptions);
-    console.log('GitService initialized.');
+    console.log('GitService initialized.')
   }
 
   /**
@@ -30,46 +45,81 @@ class GitService {
     console.log(`Attempting to clone repository: ${repoUrl}`);
 
     try {
-      // 1. Create a unique temporary directory
-      // Prefix 'git-visualizer-' helps identify these directories
       const tempDirPrefix = path.join(os.tmpdir(), 'git-visualizer-');
       tempDir = await mkdtemp(tempDirPrefix);
       console.log(`Created temporary directory: ${tempDir}`);
 
-      // 2. Configure simple-git instance for the temporary directory
-      const localGit = simpleGit(tempDir); // Operate within the new temp directory
+      const localGit = simpleGit(tempDir);
 
-      // 3. Clone the repository with limited depth
       const cloneOptions = {
         '--depth': 50,
       };
-      await localGit.clone(repoUrl, '.', cloneOptions); // Clone into the root of tempDir ('.')
+      await localGit.clone(repoUrl, '.', cloneOptions);
       console.log(`Successfully cloned ${repoUrl} into ${tempDir} with depth 50.`);
 
-      // 4. Return the path to the cloned repository directory
       return tempDir;
 
     } catch (error) {
       console.error(`Error cloning repository ${repoUrl}:`, error);
-      // Attempt to clean up the temporary directory if cloning failed
       if (tempDir) {
         try {
             console.log(`Attempting cleanup of failed clone directory: ${tempDir}`);
-            // Be careful with rm! Ensure it targets the correct directory.
             await rm(tempDir, { recursive: true, force: true });
             console.log(`Cleaned up temporary directory: ${tempDir}`);
         } catch (cleanupError) {
             console.error(`Failed to cleanup temporary directory ${tempDir}:`, cleanupError);
         }
       }
-      // Re-throw the original error to be handled by the caller
       throw new Error(`Failed to clone repository: ${repoUrl}. Reason: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
-  // --- Future methods for Git operations will go here ---
-  // Example: async getCommits(repoPath: string): Promise<Commit[]> { ... }
-  // Example: async cleanupRepository(repoPath: string): Promise<void> { ... }
+  /**
+   * Retrieves the commit history from a local repository path.
+   * @param localRepoPath The file system path to the cloned repository.
+   * @param maxCount The maximum number of commits to retrieve (default: 100).
+   * @returns A promise that resolves with an array of Commit objects.
+   * @throws Will throw an error if reading the commit log fails.
+   */
+  async getCommits(localRepoPath: string, maxCount: number = 100): Promise<Commit[]> {
+    console.log(`Attempting to read commits from: ${localRepoPath}, maxCount: ${maxCount}`);
+    try {
+      // Create a simple-git instance specifically for the repo path
+      const localGit: SimpleGit = simpleGit(localRepoPath);
+
+      // Use git.log to retrieve commits.
+      // The default log format includes the necessary fields.
+      // We limit the number of commits using maxCount.
+      const logOptions = {
+        maxCount: maxCount,
+      };
+
+      const log = await localGit.log<GitLogEntry>(logOptions); // Specify expected type
+
+      // Map the result from simple-git log to our shared Commit interface
+      const commits: Commit[] = log.all.map((entry: GitLogEntry) => {
+        // Basic validation (optional, but good practice)
+        if (!entry.hash || !entry.message || !entry.date || !entry.author_name || !entry.author_email) {
+            console.warn('Skipping commit with missing data:', entry);
+            return null; // Skip this entry if essential data is missing
+        }
+        return {
+          sha: entry.hash,
+          message: entry.message,
+          date: entry.date, // Already in ISO 8601 string format
+          authorName: entry.author_name,
+          authorEmail: entry.author_email,
+        };
+      }).filter((commit): commit is Commit => commit !== null); // Filter out any null entries
+
+      console.log(`Successfully retrieved ${commits.length} commits from ${localRepoPath}.`);
+      return commits;
+
+    } catch (error) {
+      console.error(`Error reading commits from repository ${localRepoPath}:`, error);
+      throw new Error(`Failed to get commits from repository: ${localRepoPath}. Reason: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 
    /**
    * Cleans up (deletes) the temporary repository directory.
@@ -83,15 +133,10 @@ class GitService {
             console.log(`Successfully cleaned up directory: ${repoPath}`);
         } catch (error) {
             console.error(`Error cleaning up directory ${repoPath}:`, error);
-            // Decide if you want to re-throw or just log
             throw new Error(`Failed to clean up repository directory: ${repoPath}. Reason: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 }
 
-// Export an instance or the class itself depending on your preference
-// Exporting an instance (singleton pattern) is common for services
 export const gitService = new GitService();
-
-// Or export the class if you need multiple instances
-// export default GitService;
+// export default GitService; // Uncomment if you prefer exporting the class

--- a/apps/backend/src/services/gitService.ts
+++ b/apps/backend/src/services/gitService.ts
@@ -24,7 +24,6 @@ interface GitLogEntry extends DefaultLogFields {
 }
 
 class GitService {
-  // No changes needed for the constructor or the existing cloneRepository/cleanupRepository methods
 
   private git: SimpleGit;
 

--- a/apps/backend/src/services/gitService.ts
+++ b/apps/backend/src/services/gitService.ts
@@ -1,0 +1,97 @@
+import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
+import { mkdtemp, rm } from 'fs/promises'; // Use promises API for async/await
+import path from 'path';
+import os from 'os'; // To get the system's temporary directory
+
+// Optional: Define more specific options if needed
+const gitOptions: Partial<SimpleGitOptions> = {
+  baseDir: process.cwd(), // Set the base directory for operations
+  binary: 'git',
+  maxConcurrentProcesses: 6,
+};
+
+class GitService {
+  private git: SimpleGit;
+
+  constructor() {
+    this.git = simpleGit(gitOptions);
+    console.log('GitService initialized.');
+  }
+
+  /**
+   * Clones a Git repository into a temporary directory.
+   * @param repoUrl The URL of the repository to clone.
+   * @returns A promise that resolves with the path to the temporary directory
+   * where the repository was cloned.
+   * @throws Will throw an error if cloning fails.
+   */
+  async cloneRepository(repoUrl: string): Promise<string> {
+    let tempDir: string | undefined = undefined;
+    console.log(`Attempting to clone repository: ${repoUrl}`);
+
+    try {
+      // 1. Create a unique temporary directory
+      // Prefix 'git-visualizer-' helps identify these directories
+      const tempDirPrefix = path.join(os.tmpdir(), 'git-visualizer-');
+      tempDir = await mkdtemp(tempDirPrefix);
+      console.log(`Created temporary directory: ${tempDir}`);
+
+      // 2. Configure simple-git instance for the temporary directory
+      const localGit = simpleGit(tempDir); // Operate within the new temp directory
+
+      // 3. Clone the repository with limited depth
+      const cloneOptions = {
+        '--depth': 50,
+      };
+      await localGit.clone(repoUrl, '.', cloneOptions); // Clone into the root of tempDir ('.')
+      console.log(`Successfully cloned ${repoUrl} into ${tempDir} with depth 50.`);
+
+      // 4. Return the path to the cloned repository directory
+      return tempDir;
+
+    } catch (error) {
+      console.error(`Error cloning repository ${repoUrl}:`, error);
+      // Attempt to clean up the temporary directory if cloning failed
+      if (tempDir) {
+        try {
+            console.log(`Attempting cleanup of failed clone directory: ${tempDir}`);
+            // Be careful with rm! Ensure it targets the correct directory.
+            await rm(tempDir, { recursive: true, force: true });
+            console.log(`Cleaned up temporary directory: ${tempDir}`);
+        } catch (cleanupError) {
+            console.error(`Failed to cleanup temporary directory ${tempDir}:`, cleanupError);
+        }
+      }
+      // Re-throw the original error to be handled by the caller
+      throw new Error(`Failed to clone repository: ${repoUrl}. Reason: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // --- Future methods for Git operations will go here ---
+  // Example: async getCommits(repoPath: string): Promise<Commit[]> { ... }
+  // Example: async cleanupRepository(repoPath: string): Promise<void> { ... }
+
+   /**
+   * Cleans up (deletes) the temporary repository directory.
+   * @param repoPath The path to the directory to delete.
+   * @returns A promise that resolves when cleanup is complete.
+   */
+    async cleanupRepository(repoPath: string): Promise<void> {
+        console.log(`Attempting cleanup of directory: ${repoPath}`);
+        try {
+            await rm(repoPath, { recursive: true, force: true });
+            console.log(`Successfully cleaned up directory: ${repoPath}`);
+        } catch (error) {
+            console.error(`Error cleaning up directory ${repoPath}:`, error);
+            // Decide if you want to re-throw or just log
+            throw new Error(`Failed to clean up repository directory: ${repoPath}. Reason: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+}
+
+// Export an instance or the class itself depending on your preference
+// Exporting an instance (singleton pattern) is common for services
+export const gitService = new GitService();
+
+// Or export the class if you need multiple instances
+// export default GitService;

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -27,9 +27,11 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    "paths": {
+      "shared-types": ["../../packages/shared-types/dist"]
+    },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -116,7 +118,7 @@
   ],
   "references": [
     {
-      "path": "../shared-types"  // Add this: path to the shared-types package
+      "path": "../../packages/shared-types"  // Add this: path to the shared-types package
     }
   ]
 }

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -55,7 +55,7 @@
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSourceMap": true,                          /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
@@ -97,8 +97,8 @@
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noFallthroughCasesInSwitch": true,                /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                  /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
@@ -107,5 +107,16 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../shared-types"  // Add this: path to the shared-types package
+    }
+  ]
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "shared-types",
+  "version": "1.0.0"
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,4 +1,11 @@
 {
   "name": "shared-types",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "scripts": {
+    "build": "pnpm exec tsc"
+  },
+  "main": "./dist/index.js",
+  "devDependencies": {
+    "typescript": "~5.7.2"
+  }
 }

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "composite": true, // Very important for project references
+    "declaration": true, // Generate .d.ts files
+    "declarationMap": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2016",
+    "lib": ["es2017", "esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist" // Output directory for declarations
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -11,7 +11,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist" // Output directory for declarations
+    "outDir": "dist", // Output directory for declarations
+    "declarationDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
 
+  packages/shared-types: {}
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,11 @@ importers:
         specifier: ^6.2.0
         version: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
 
-  packages/shared-types: {}
+  packages/shared-types:
+    devDependencies:
+      typescript:
+        specifier: ~5.7.2
+        version: 5.7.3
 
 packages:
 


### PR DESCRIPTION
Closes #9 
Closes #10 
## Funktionsweise:
- Der Service initialisiert simple-git.
- Die Methode cloneRepository nimmt eine URL entgegen.
- Sie erstellt mit fs/promises.mkdtemp ein eindeutiges temporäres Verzeichnis im Standard-Temp-Ordner des Betriebssystems (z.B. /tmp/git-visualizer-XXXXXX).
- Sie klont das Repository mit simpleGit().clone() in dieses Verzeichnis hinein. Die Option --depth=50 begrenzt die Historie, was für schnellere Downloads sorgt.
- Bei Erfolg gibt die Methode den Pfad zum temporären Verzeichnis zurück. Dieser Pfad kann dann für weitere Git-Operationen (wie das Auslesen von Commits) verwendet werden.
- Bei Fehlern wird eine Fehlermeldung geloggt, versucht, das unvollständige temporäre Verzeichnis zu löschen, und der Fehler wird weitergeworfen, damit er von aufrufendem Code behandelt werden kann.
- Eine cleanupRepository-Methode wurde hinzugefügt, um das temporäre Verzeichnis nach Gebrauch explizit löschen zu können.


---

Zusätzlich noch shared-types Error gefixt --> kann jetzt von front & backend benutzt werden.
Der Build Workflow musste dementsprechend angepasst werden.