### PR TITLE
Fix parsing of commit messages with pipe

### DIFF
--- a/apps/backend/__tests__/services/gitService.test.ts
+++ b/apps/backend/__tests__/services/gitService.test.ts
@@ -201,6 +201,22 @@ describe('GitService Extended Tests', () => {
       expect(warnSpy).toHaveBeenCalledTimes(2);
       warnSpy.mockRestore();
     });
+
+    test('should handle commit messages containing pipe characters', async () => {
+      const localRepoPath = '/tmp/git-visualizer-test';
+      const mockRaw =
+        'abc123|2023-01-01T12:00:00Z|Test User|test@example.com|feat: use A | B';
+      mockGit.raw.mockResolvedValue(mockRaw);
+      const commits = await gitService.getCommits(localRepoPath);
+      expect(commits).toHaveLength(1);
+      expect(commits[0]).toEqual({
+        sha: 'abc123',
+        message: 'feat: use A | B',
+        date: '2023-01-01T12:00:00Z',
+        authorName: 'Test User',
+        authorEmail: 'test@example.com',
+      });
+    });
   });
 
   describe('cleanupRepository error handling', () => {

--- a/apps/backend/src/services/gitService.ts
+++ b/apps/backend/src/services/gitService.ts
@@ -108,8 +108,9 @@ class GitService {
         .split('\n')
         .filter(Boolean)
         .map((line) => {
-          const [hash, date, authorName, authorEmail, message] =
-            line.split('|');
+          const parts = line.split('|');
+          const [hash, date, authorName, authorEmail] = parts;
+          const message = parts.slice(4).join('|');
           if (!hash || !date || !authorName || !authorEmail || !message) {
             logger.warn('Skipping commit with missing data', { line });
             return null;


### PR DESCRIPTION
## Summary
- handle pipe characters when parsing commit logs
- test gitService with commit messages containing pipe characters

## Testing
- `pnpm lint && pnpm lint:md`
- `pnpm build`
- `pnpm test`
- `pnpm dev` *(for 5 seconds)*