### PR TITLE
Sort authors dropdown by commit count

### DIFF
--- a/apps/frontend/__tests__/components/ActivityHeatmap.test.tsx
+++ b/apps/frontend/__tests__/components/ActivityHeatmap.test.tsx
@@ -1,4 +1,5 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ActivityHeatmap from '../../src/components/ActivityHeatmap';
 import { getHeatmapData } from '../../src/services/api';
 
@@ -55,5 +56,48 @@ describe('ActivityHeatmap (happy path, AAA)', () => {
     // Assert
     const rects = container.querySelectorAll('rect.color-scale-4');
     expect(rects.length).toBeGreaterThan(0);
+  });
+
+  test('sorts authors in dropdown by commit count', async () => {
+    // Arrange
+    mockedGetHeatmapData.mockResolvedValue({
+      timePeriod: 'day',
+      data: [],
+      metadata: { maxCommitCount: 0, totalCommits: 0 },
+    });
+    const commits = [
+      {
+        sha: '1',
+        message: 'm',
+        date: new Date().toISOString(),
+        authorName: 'Bob',
+        authorEmail: 'bob@example.com',
+      },
+      {
+        sha: '2',
+        message: 'm',
+        date: new Date().toISOString(),
+        authorName: 'Alice',
+        authorEmail: 'alice@example.com',
+      },
+      {
+        sha: '3',
+        message: 'm',
+        date: new Date().toISOString(),
+        authorName: 'Bob',
+        authorEmail: 'bob@example.com',
+      },
+    ];
+
+    // Act
+    render(<ActivityHeatmap repoUrl="url" commits={commits} />);
+    await waitFor(() => expect(mockedGetHeatmapData).toHaveBeenCalled());
+    const combo = screen.getByRole('combobox');
+    await userEvent.click(combo);
+    const options = screen.getAllByRole('option');
+
+    // Assert
+    expect(options[0].textContent).toContain('Bob (2)');
+    expect(options[1].textContent).toContain('Alice (1)');
   });
 });

--- a/apps/frontend/src/components/ActivityHeatmap.tsx
+++ b/apps/frontend/src/components/ActivityHeatmap.tsx
@@ -40,6 +40,7 @@ interface HeatmapValue {
 interface AuthorOption {
   value: string;
   label: string;
+  count?: number;
 }
 
 const customStyles: StylesConfig<
@@ -121,13 +122,16 @@ const ActivityHeatmap: React.FC<ActivityHeatmapProps> = ({
     return counts;
   }, [commits, startDate, endDate]);
 
-  // Build dropdown options including the count
+  // Build dropdown options including the count and sort by commit count
   const authorOptions = useMemo(
     () =>
-      Array.from(new Set(commits.map((c) => c.authorName))).map((a) => ({
-        value: a,
-        label: `${a} (${authorCommitCounts.get(a) || 0})`,
-      })),
+      Array.from(new Set(commits.map((c) => c.authorName)))
+        .map((a) => ({
+          value: a,
+          label: `${a} (${authorCommitCounts.get(a) || 0})`,
+          count: authorCommitCounts.get(a) || 0,
+        }))
+        .sort((a, b) => b.count - a.count),
     [commits, authorCommitCounts]
   );
 


### PR DESCRIPTION
## Summary
- sort ActivityHeatmap author options by commit count
- test author dropdown sorting

## Testing
- `pnpm lint && pnpm lint:md`
- `pnpm build`
- `pnpm test --silent`
- `pnpm dev` *(fails: Terminated after start)*

------
https://chatgpt.com/codex/tasks/task_b_683e52af64808330bd68a259b14cc4d4