### PR TITLE
feat(backend): concurrency locks

### DIFF
--- a/apps/backend/__tests__/utils/lockManager.test.ts
+++ b/apps/backend/__tests__/utils/lockManager.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { withKeyLock } from '../../src/utils/lockManager';
+
+describe('withKeyLock', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'locktest-'));
+    process.env.LOCK_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    delete process.env.LOCK_DIR;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('serializes concurrent calls for the same key', async () => {
+    let counter = 0;
+    const fn = async () => {
+      counter += 1;
+      await new Promise((r) => setTimeout(r, 50));
+      return counter;
+    };
+
+    const [a, b] = await Promise.all([
+      withKeyLock('repo', fn),
+      withKeyLock('repo', fn),
+    ]);
+
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(counter).toBe(1);
+  });
+});

--- a/apps/backend/src/utils/lockManager.ts
+++ b/apps/backend/src/utils/lockManager.ts
@@ -1,0 +1,91 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import logger from '../services/logger';
+
+// Simple file-based lock mechanism for cross-process coordination
+const LOCK_ROOT =
+  process.env.LOCK_DIR || path.join(os.tmpdir(), 'gitray-locks');
+const DEFAULT_TIMEOUT = Number(process.env.CACHE_LOCK_TIMEOUT_MS) || 120000; // 2 min
+
+const inflight = new Map<string, Promise<unknown>>();
+
+async function ensureDir(): Promise<void> {
+  await fs.mkdir(LOCK_ROOT, { recursive: true });
+}
+
+async function tryRemoveIfStale(
+  lockPath: string,
+  timeout: number
+): Promise<void> {
+  try {
+    const stat = await fs.stat(lockPath);
+    if (Date.now() - stat.mtimeMs > timeout) {
+      await fs.unlink(lockPath);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+async function acquire(
+  lockKey: string,
+  timeout = DEFAULT_TIMEOUT
+): Promise<fs.FileHandle> {
+  await ensureDir();
+  const lockPath = path.join(LOCK_ROOT, encodeURIComponent(lockKey));
+  const start = Date.now();
+  while (true) {
+    try {
+      return await fs.open(lockPath, 'wx');
+    } catch (err: any) {
+      if (err.code !== 'EEXIST') throw err;
+      await tryRemoveIfStale(lockPath, timeout);
+      if (Date.now() - start > timeout) {
+        throw new Error(`Lock timeout for ${lockKey}`);
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+}
+
+async function release(handle: fs.FileHandle, lockKey: string): Promise<void> {
+  const lockPath = path.join(LOCK_ROOT, encodeURIComponent(lockKey));
+  try {
+    await handle.close();
+  } catch (err) {
+    logger.warn('Failed to close lock handle', { lockKey, err });
+  }
+  try {
+    await fs.unlink(lockPath);
+  } catch (err) {
+    logger.warn('Failed to remove lock file', { lockKey, err });
+  }
+}
+
+export async function withKeyLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  timeout = DEFAULT_TIMEOUT
+): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) {
+    return existing;
+  }
+
+  const promise = (async () => {
+    const handle = await acquire(key, timeout);
+    try {
+      return await fn();
+    } finally {
+      await release(handle, key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  try {
+    return await promise;
+  } finally {
+    inflight.delete(key);
+  }
+}

--- a/apps/backend/src/utils/withTempRepository.ts
+++ b/apps/backend/src/utils/withTempRepository.ts
@@ -1,5 +1,6 @@
 import { gitService } from '../services/gitService';
 import { scheduleCleanup } from './cleanupScheduler';
+import { withKeyLock } from './lockManager';
 
 // Helper that clones a repository, runs a callback, then schedules cleanup
 
@@ -10,9 +11,11 @@ export async function withTempRepository<T>(
   let tempDir: string | undefined;
 
   try {
-    // Clone the repository and forward the temp directory to the callback
-    tempDir = await gitService.cloneRepository(repoUrl);
-    return await callback(tempDir);
+    return await withKeyLock(repoUrl, async () => {
+      // Clone the repository and forward the temp directory to the callback
+      tempDir = await gitService.cloneRepository(repoUrl);
+      return await callback(tempDir);
+    });
   } finally {
     if (tempDir) {
       // Ensure cleanup even if the callback throws


### PR DESCRIPTION
## Summary
- add simple lock manager using filesystem locks
- integrate lock manager in `withTempRepository`
- test lock manager to ensure calls are serialized

## Testing
- `pnpm lint && pnpm lint:md`
- `pnpm build`
- `CI=true pnpm test --silent`
- `pnpm dev` *(fails: Local package.json exists, but node_modules missing, did you mean to install?)*

------
https://chatgpt.com/codex/tasks/task_b_683fe0f73f34833090a0ba147d6e8a4f