### PR TITLE
Add Rive loading indicator

### DIFF
--- a/apps/frontend/jest.config.cjs
+++ b/apps/frontend/jest.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
     // CSS-Module
     '\\.css$': 'identity-obj-proxy',
     // Stub für Bild- und SVG-Imports
-    '\\.(svg|jpg|jpeg|png|gif|webp)$': '<rootDir>/__mocks__/fileMock.cjs',
+    '\\.(svg|jpg|jpeg|png|gif|webp|riv)$': '<rootDir>/__mocks__/fileMock.cjs',
     // Mock problematic ESM modules
     '^ansi-styles$': '<rootDir>/__mocks__/ansi-styles.cjs',
   },
@@ -21,7 +21,7 @@ module.exports = {
       },
     ],
     // Assets
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|riv)$':
       'jest-transform-stub',
   },
 

--- a/apps/frontend/src/components/ActivityHeatmap.tsx
+++ b/apps/frontend/src/components/ActivityHeatmap.tsx
@@ -24,6 +24,7 @@ import {
   TIME,
 } from '@gitray/shared-types';
 import { getHeatmapData } from '../services/api';
+import { useLoading } from '../context/LoadingContext';
 
 interface ActivityHeatmapProps {
   repoUrl: string;
@@ -110,6 +111,7 @@ const ActivityHeatmap: React.FC<ActivityHeatmapProps> = ({
   const [loading, setLoading] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const { showLoading, hideLoading } = useLoading();
 
   // memoize start/end dates to avoid unstable deps
   const startDate = useMemo(() => new Date(Date.now() - TIME.DAY * 364), []);
@@ -189,13 +191,15 @@ const ActivityHeatmap: React.FC<ActivityHeatmapProps> = ({
   const fetchData = useCallback(async () => {
     if (!repoUrl) return;
     setLoading(true);
+    showLoading();
     try {
       const d = await getHeatmapData(repoUrl, 'day', filterOptions);
       setData(d);
     } finally {
       setLoading(false);
+      hideLoading();
     }
-  }, [repoUrl, filterOptions]);
+  }, [repoUrl, filterOptions, showLoading, hideLoading]);
 
   // Only call fetchData when filters changed
   const handleMenuClose = () => {
@@ -259,11 +263,6 @@ const ActivityHeatmap: React.FC<ActivityHeatmapProps> = ({
             }
             placeholder="Select author(s) to filter..."
           />
-          {loading && (
-            <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-              <div className="animate-spin h-5 w-5 border-2 border-green-500 border-t-transparent rounded-full" />
-            </div>
-          )}
         </div>
         <br></br>
         {/* Heatmap container with dynamic sizing */}

--- a/apps/frontend/src/components/LoadingAnimation.tsx
+++ b/apps/frontend/src/components/LoadingAnimation.tsx
@@ -1,0 +1,18 @@
+import { useRive } from '@rive-app/react-canvas';
+import React from 'react';
+import LoadingAsset from '../assets/Logo_Animation_StateMachine_DarkMode.riv';
+
+/**
+ * Displays the "Loading" animation from the Rive asset.
+ */
+const LoadingAnimation: React.FC<{ className?: string }> = ({ className }) => {
+  const { RiveComponent } = useRive({
+    src: LoadingAsset,
+    animations: 'Loading',
+    autoplay: true,
+  });
+
+  return <RiveComponent className={className} />;
+};
+
+export default LoadingAnimation;

--- a/apps/frontend/src/context/LoadingContext.tsx
+++ b/apps/frontend/src/context/LoadingContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import LoadingAnimation from '../components/LoadingAnimation';
+
+interface LoadingContextValue {
+  isLoading: boolean;
+  showLoading: () => void;
+  hideLoading: () => void;
+}
+
+const LoadingContext = createContext<LoadingContextValue>({
+  isLoading: false,
+  showLoading: () => {},
+  hideLoading: () => {},
+});
+
+export const LoadingProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const showLoading = () => setIsLoading(true);
+  const hideLoading = () => setIsLoading(false);
+
+  return (
+    <LoadingContext.Provider value={{ isLoading, showLoading, hideLoading }}>
+      {children}
+      {isLoading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+          <LoadingAnimation className="w-32 h-32" />
+        </div>
+      )}
+    </LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => useContext(LoadingContext);

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { LoadingProvider } from './context/LoadingContext';
 
 /**
  * Application bootstrap that mounts the React component tree into the DOM.
@@ -10,6 +11,8 @@ import App from './App.tsx';
 // Mount the root React component tree
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <LoadingProvider>
+      <App />
+    </LoadingProvider>
   </StrictMode>
 );

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useLoading } from '../context/LoadingContext';
 
 /**
  * Main application page that orchestrates repository input and visualizations.
@@ -18,10 +19,10 @@ import { Commit } from '@gitray/shared-types';
  */
 const MainPage: React.FC = () => {
   const [commits, setCommits] = useState<Commit[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [repoUrl, setRepoUrl] = useState<string>('');
   const [showHeatmap, setShowHeatmap] = useState<boolean>(false);
+  const { isLoading, showLoading, hideLoading } = useLoading();
 
   /**
    * Fetches repository data when the user requests visualization of a new
@@ -31,7 +32,7 @@ const MainPage: React.FC = () => {
     // Trigger data fetch for the entered repository URL
     console.log('Visualizing:', inputRepoUrl);
     setRepoUrl(inputRepoUrl);
-    setIsLoading(true);
+    showLoading();
     setError(null);
 
     try {
@@ -47,7 +48,7 @@ const MainPage: React.FC = () => {
       setCommits([]);
       setShowHeatmap(false);
     } finally {
-      setIsLoading(false);
+      hideLoading();
     }
   };
 
@@ -66,14 +67,6 @@ const MainPage: React.FC = () => {
       {/* Main area */}
       <main className="w-full max-w-4xl mx-auto flex flex-col flex-grow space-y-8 px-4">
         <RepoInput onVisualize={handleVisualize} />
-
-        {isLoading && (
-          <div className="mt-8 text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-500 mx-auto"></div>
-            <p className="mt-2 text-gray-400">Loading repository data...</p>
-          </div>
-        )}
-
         {error && (
           <div className="mt-8 p-4 bg-red-900 border border-red-700 text-red-200 rounded-md">
             <p>

--- a/apps/frontend/src/types/rive.d.ts
+++ b/apps/frontend/src/types/rive.d.ts
@@ -1,0 +1,4 @@
+declare module '*.riv' {
+  const src: string;
+  export default src;
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -25,7 +25,8 @@ module.exports = {
       rootDir: './',
       testPathIgnorePatterns: ['/node_modules/'],
       moduleNameMapper: {
-        '^@gitray/shared-types$': '<rootDir>/packages/shared-types/src/index.ts',
+        '^@gitray/shared-types$':
+          '<rootDir>/packages/shared-types/src/index.ts',
       },
       globals: {
         'ts-jest': {
@@ -46,17 +47,18 @@ module.exports = {
           { tsconfig: 'apps/frontend/tsconfig.jest.json' },
         ],
         // ➞ Assets stubben
-        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|riv)$':
           'jest-transform-stub',
       },
 
       moduleNameMapper: {
         '\\.css$': 'identity-obj-proxy',
-        '\\.(svg|jpg|jpeg|png|gif|webp)$':
+        '\\.(svg|jpg|jpeg|png|gif|webp|riv)$':
           '<rootDir>/apps/frontend/__mocks__/fileMock.cjs',
         '^/vite\\.svg$': '<rootDir>/apps/frontend/__mocks__/fileMock.cjs',
         '^ansi-styles$': '<rootDir>/apps/frontend/__mocks__/ansi-styles.cjs',
-        '^@gitray/shared-types$': '<rootDir>/packages/shared-types/src/index.ts',
+        '^@gitray/shared-types$':
+          '<rootDir>/packages/shared-types/src/index.ts',
       },
       setupFilesAfterEnv: ['<rootDir>/apps/frontend/jest.setup.ts'],
       moduleDirectories: [


### PR DESCRIPTION
## Summary
- integrate `@rive-app/react-canvas` loader
- implement global LoadingContext with overlay
- show Rive animation during async operations
- handle .riv imports in Jest configs

## Testing
- `pnpm lint`
- `pnpm lint:md`
- `pnpm build`
- `pnpm test --silent`
- `pnpm dev` *(fails: Command failed)*

------
https://chatgpt.com/codex/tasks/task_b_6849591ac2b083319b07add4c3a2418e